### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ means you can better manage cost.
 - `Product Documentation`_
 
 .. |GA| image:: https://img.shields.io/badge/support-ga-gold.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-api-gateway.svg
    :target: https://pypi.org/project/google-cloud-api-gateway/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-api-gateway.svg
@@ -83,4 +83,4 @@ Next Steps
    APIs that we cover.
 
 .. _API Gateway Product documentation:  https://cloud.google.com/api-gateway/docs
-.. _README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.