### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "apigateway",
     "name_pretty": "API Gateway",
     "product_documentation": "https://cloud.google.com/api-gateway",
-    "client_documentation": "https://googleapis.dev/python/apigateway/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/apigateway/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ means you can better manage cost.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-api-gateway.svg
    :target: https://pypi.org/project/google-cloud-api-gateway/
 .. _API Gateway: https://cloud.google.com/api-gateway
-.. _Client Library Documentation: https://googleapis.dev/python/apigateway/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/apigateway/latest
 .. _Product Documentation:  https://cloud.google.com/api-gateway
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.